### PR TITLE
Quarto project / output config for Docusaurus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/.quarto/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,14 @@
+project:
+  render: 
+    - "**/*.qmd"
+    - "**/*.ipynb"
+
+format:
+  commonmark:
+    variant: +tex_math_dollars
+    keep-yaml: true
+    wrap: none
+    filters: 
+      - docusaurus.lua
+      - quarto
+    

--- a/blog/2021-08-01-mdx-blog-post.qmd
+++ b/blog/2021-08-01-mdx-blog-post.qmd
@@ -8,13 +8,16 @@ output-ext: mdx
 
 Blog posts support [Docusaurus Markdown features](https://docusaurus.io/docs/markdown-features), such as [MDX](https://mdxjs.com/).
 
-:::tip
+::: {.callout-tip}
 
 Use the power of React to create interactive blog posts.
 
-``` js
+```js
 <button onClick={() => alert('button clicked!')}>Click me!</button>
 ```
 
+```{=html}
 <button onClick={() => alert('button clicked!')}>Click me!</button>
+```
+
 :::

--- a/blog/2021-08-26-welcome/index.md
+++ b/blog/2021-08-26-welcome/index.md
@@ -7,7 +7,7 @@ tags: [facebook, hello, docusaurus]
 
 [Docusaurus blogging features](https://docusaurus.io/docs/blog) are powered by the [blog plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog).
 
-Simply add Markdown files (or even folders) to the `blog` directory.
+Simply add Markdown files (or folders) to the `blog` directory.
 
 Regular blog authors can be added to `authors.yml`.
 

--- a/blog/2021-08-26-welcome/index.qmd
+++ b/blog/2021-08-26-welcome/index.qmd
@@ -13,8 +13,8 @@ Regular blog authors can be added to `authors.yml`.
 
 The blog post date can be extracted from filenames, such as:
 
--   `2019-05-30-welcome.md`
--   `2019-05-30-welcome/index.md`
+- `2019-05-30-welcome.md`
+- `2019-05-30-welcome/index.md`
 
 A blog post folder can be convenient to co-locate blog post images:
 
@@ -22,19 +22,19 @@ A blog post folder can be convenient to co-locate blog post images:
 
 The blog supports tags as well!
 
-**And if you don’t want a blog**: just delete this directory, and use `blog: false` in your Docusaurus config.
+**And if you don't want a blog**: just delete this directory, and use `blog: false` in your Docusaurus config.
 
 Code block with title (transformed by docusaurus.lua to Docusaurus native syntax)
 
-```python title="My title"
+```{.python title="My title"}
 def hello():
   return "hello, world"
 ```
 
 Callout (transformed by docusaurus.lua to Docusaurus native syntax)
 
-:::note
-
+::: callout-note
 This is a callout.
-
 :::
+
+

--- a/blog/2021-08-26-welcome/index.qmd
+++ b/blog/2021-08-26-welcome/index.qmd
@@ -7,7 +7,7 @@ tags: [facebook, hello, docusaurus]
 
 [Docusaurus blogging features](https://docusaurus.io/docs/blog) are powered by the [blog plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog).
 
-Simply add Markdown files (or even folders) to the `blog` directory.
+Simply add Markdown files (or folders) to the `blog` directory.
 
 Regular blog authors can be added to `authors.yml`.
 

--- a/docusaurus.lua
+++ b/docusaurus.lua
@@ -1,0 +1,44 @@
+
+
+-- transform pandoc "title" to docusaures title
+function CodeBlock(el)
+  local lang = el.attr.classes[1]
+  local title = el.attr.attributes["title"]
+  if lang and title then
+    -- docusaures code block attributes don't conform to any syntax
+    -- that pandoc natively understands, so return the CodeBlock as
+    -- "raw" markdown (so it bypasses pandoc processing entirely)
+    return pandoc.RawBlock("markdown", 
+      "```" .. lang .. " title=\"" .. title .. "\"\n" ..
+      el.text .. "\n```\n"
+    )
+  end
+end
+
+-- transform quarto callout into docusaures admonition
+function Div(el)
+  local callout = calloutType(el)
+  if callout then
+    -- return a list with the callout delimiters as raw markdown
+    -- and the callout contents as ordinary ast elements
+    local admonition = pandoc.List()
+    admonition:insert(pandoc.RawBlock("markdown", ":::" .. callout))
+    admonition:extend(el.content)
+    admonition:insert(pandoc.RawBlock("markdown", ":::"))
+    return admonition
+  end
+end
+
+
+function calloutType(div)
+  for _, class in ipairs(div.attr.classes) do
+    if isCallout(class) then 
+      return class:match("^callout%-(.*)")
+    end
+  end
+  return nil
+end
+
+function isCallout(class)
+  return class == 'callout' or class:match("^callout%-")
+end


### PR DESCRIPTION
This PR demonstrates how to use Quarto to render `.qmd` and `.ipynb` files into Docusaurus-compatible `.md` and `.mdx` files. The following are added to the the standard Docusaurus demo project (generated with `npx create-docusaurus@latest website classic`):

-   A `_quarto.yml` project file and `docusaurus.lua` filter
-   `.qmd` versions of the `blog/2021-08-26-welcome/index.md` and `blog/2021-08-01-mdx-blog-post.mdx` posts (these in turn generate the respective `.md` and `.mdx` files when rendered.

The `_quarto.yml` file looks like this:

``` yaml
project:
  render: 
    - "**/*.qmd"
    - "**/*.ipynb"

format:
  commonmark:
    variant: +tex_math_dollars
    keep-yaml: true
    wrap: none
    filters: 
      - docusaurus.lua
      - quarto
```

This project file will render all `.qmd` and `.ipynb` files in the directory (it skips `.md`). The markdown variant will be `commonmark` (with tex math) and the original YAML written by the user will be preserved. A Docusaurus filter is also run prior to the Quarto filters---this filter translates Pandoc fenced code blocks with a "title" attribute to the equivalent Docusaurus syntax and translates Quarto callouts to Docusaurus admonitions.

The input markdown can use the full capabilities of pandoc markdown (the output will be appropriately downleveled to `commonmark`). As such, the input should conform to Pandoc rather than Docusaurus markdown. For example, on the left is Pandoc markdown and on the right what is written to the Docusaurus `.md` or `.mdx`:


<table>
<colgroup>
<col style="width: 50%" />
<col style="width: 50%" />
</colgroup>
<thead>
<tr class="header">
<th>Pandoc</th>
<th>Docusaurus</th>
</tr>
</thead>
<tbody>
<tr class="odd">
<td><pre><code>```{.python title=&quot;My title&quot;}
def hello():
  return &quot;hello, world&quot;
```</code></pre></td>
<td><pre><code>```python title=&quot;My title&quot;
def hello():
  return &quot;hello, world&quot;
```</code></pre></td>
</tr>
<tr class="even">
<td><pre><code>::: callout-note
This is a callout.
:::</code></pre></td>
<td><pre><code>:::note
This is a callout.
:::</code></pre></td>
</tr>
<tr class="odd">
<td><pre><code>```{=html}
&lt;button onClick={() =&gt; alert(&#39;button clicked!&#39;)}&gt;
  Click me!
&lt;/button&gt;
```</code></pre></td>
<td><pre><code>&lt;button onClick={() =&gt; alert(&#39;button clicked!&#39;)}&gt;
  Click me!
&lt;/button&gt;</code></pre></td>
</tr>
</tbody>
</table>

The final example demonstrates escaping MDX syntax using Pandoc Raw HTML blocks (this is necessary to prevent Pandoc from processing the MDX content as markdown).

To generate an MDX file, we add the following metadata to `blog/2021-08-01-mdx-blog-post.qmd`:

```yaml
output-ext: mdx
```

Note that this same metadata can be included in a Raw cell in an `ipynb` file (which could in turn be injected by an `ipynb-filter`).
